### PR TITLE
Fix Vercel deployment: replace routes with rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,10 +10,10 @@
       }
     }
   ],
-  "routes": [
+  "rewrites": [
     {
-      "src": "/(.*)",
-      "dest": "/index.html"
+      "source": "/(.*)",
+      "destination": "/index.html"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Purpose
The user was attempting to deploy a mobile app and website separately on Vercel but encountered deployment errors. The issue was caused by using deprecated `routes` configuration in vercel.json, which conflicts with other routing configurations like `headers`, `redirects`, or `rewrites`.

## Code changes
- Replaced deprecated `routes` array with `rewrites` array in vercel.json
- Updated property names from `src`/`dest` to `source`/`destination` to match the rewrites syntax
- Maintained the same routing behavior (catch-all route to index.html) while fixing the configuration conflict

This resolves the Vercel deployment error and allows proper deployment of the application.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a429c1a807a6410988a85116f8031bef/pulse-studio)

👀 [Preview Link](https://a429c1a807a6410988a85116f8031bef-pulse-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a429c1a807a6410988a85116f8031bef</projectId>-->
<!--<branchName>pulse-studio</branchName>-->