### PR TITLE
Configure separate Vercel deployments for mobile and web

### DIFF
--- a/mobile-app-configs/vercel.json
+++ b/mobile-app-configs/vercel.json
@@ -1,12 +1,13 @@
 {
   "name": "health-surveillance-mobile",
   "version": 2,
+  "buildCommand": "pnpm -C .. build:mobile",
   "builds": [
     {
       "src": "package.json",
       "use": "@vercel/static-build",
       "config": {
-        "distDir": "dist"
+        "distDir": "dist/mobile"
       }
     }
   ],

--- a/vercel.json
+++ b/vercel.json
@@ -1,14 +1,10 @@
 {
   "version": 2,
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
-  ],
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
   "headers": [
     {
       "source": "/sw.js",
-      "headers": [
-        { "key": "Cache-Control", "value": "no-cache" }
-      ]
+      "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,29 +1,13 @@
 {
-  "name": "health-surveillance",
   "version": 2,
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/static-build",
-      "config": {
-        "distDir": "dist/spa"
-      }
-    }
-  ],
   "rewrites": [
-    {
-      "source": "/(.*)",
-      "destination": "/index.html"
-    }
+    { "source": "/(.*)", "destination": "/index.html" }
   ],
   "headers": [
     {
       "source": "/sw.js",
       "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "no-cache"
-        }
+        { "key": "Cache-Control", "value": "no-cache" }
       ]
     }
   ]

--- a/web-app-configs/vercel.json
+++ b/web-app-configs/vercel.json
@@ -1,12 +1,13 @@
 {
   "name": "health-surveillance-web",
   "version": 2,
+  "buildCommand": "pnpm -C .. build:web",
   "builds": [
     {
       "src": "package.json",
       "use": "@vercel/static-build",
       "config": {
-        "distDir": "dist"
+        "distDir": "dist/web"
       }
     }
   ],


### PR DESCRIPTION
## Purpose
The user wanted to deploy mobile and website applications separately on Vercel instead of having both deploy together. They needed manual configuration steps to enable independent deployments without having to redeploy everything, specifically wanting to deploy only the built dist files for each application.

## Code changes
- **Mobile app config**: Added `buildCommand` to run mobile-specific build and updated `distDir` to point to `dist/mobile`
- **Web app config**: Added `buildCommand` to run web-specific build and updated `distDir` to point to `dist/web`  
- **Root config**: Simplified main `vercel.json` by removing build configuration and keeping only routing/header rules
- **Build commands**: Both configs now use `pnpm -C ..` to run builds from parent directory with specific targets (`build:mobile` and `build:web`)

This setup enables separate deployment of mobile and web applications with their own build processes and output directories.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a429c1a807a6410988a85116f8031bef/mystic-haven)

👀 [Preview Link](https://a429c1a807a6410988a85116f8031bef-mystic-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a429c1a807a6410988a85116f8031bef</projectId>-->
<!--<branchName>mystic-haven</branchName>-->